### PR TITLE
Update wflightning.php

### DIFF
--- a/www/wflightning.php
+++ b/www/wflightning.php
@@ -1,7 +1,7 @@
 <?php include('settings.php');include('shared.php');date_default_timezone_set($TZ);header('Content-type: text/html; charset=utf-8');error_reporting(0);?>
 <body>
 <?php 
-$url2 = 'https://swd.weatherflow.com/swd/rest/observations/station/'.$weatherflowID.'?api_key=5675886d24b02a37107eb5076d5e1d9f'; 
+$url2 = 'https://swd.weatherflow.com/swd/rest/observations/station/'.$weatherflowID.'?api_key=THIS_NEEDS_TO_BE_ID_LINKED'; 
 $ch2 = curl_init($url2);
 $filename2 = 'jsondata/wf.txt';
 $complete_save_loc2 = $filename2; 


### PR DESCRIPTION
That api_key yields empty UNAUTHORIZED jsondata/wf.txt result from weatherflow.com!
The API key or 'Data token' as they call it, is linked per device ID (and created by/per wf-device-owner).
See also https://weatherflow.github.io/Tempest/api/ -> "Your users will need to sign in to the Tempest Web App at tempestwx.com, then go to Settings -> Data Authorizations -> Create Token, then copy & paste that token into your app."

So you'll have to ask user to create one and fill that in via easyW34skinsetup.php.
I'm merely killing the invalid api_key with this change and let you take up coding from there.